### PR TITLE
Fix issue 11

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -126,7 +126,7 @@ module.exports = {
 			let objKeys = Object.keys(data.dante);
 	
 			for (let i = 0; i < objKeys.length; i++) {
-				let inputNumber = objKeys[i].toString();
+				let inputNumber = "D" + objKeys[i].toString();
 				let inputName = 'Dante ' + objKeys[i];
 	
 				let inputChannelObj = {
@@ -146,7 +146,7 @@ module.exports = {
 	
 				if (parseInt(inputNumber) % 2 === 0) {
 					//even number, so create the stereo channel with the previous channel
-					inputNumber = objKeys[i-1] + '_' + objKeys[i];
+					inputNumber = "D" + objKeys[i-1] + '_' + objKeys[i];
 					inputName = 'Dante ' + objKeys[i-1] + '+' + objKeys[i];
 	
 					inputChannelObj = {

--- a/src/utils.js
+++ b/src/utils.js
@@ -144,7 +144,7 @@ module.exports = {
 	
 				self.inputs.push(inputObj);
 	
-				if (parseInt(inputNumber) % 2 === 0) {
+				if (parseInt(objKeys[i].toString()) % 2 === 0) {
 					//even number, so create the stereo channel with the previous channel
 					inputNumber = "D" + objKeys[i-1] + '_' + objKeys[i];
 					inputName = 'Dante ' + objKeys[i-1] + '+' + objKeys[i];
@@ -181,7 +181,7 @@ module.exports = {
 	
 				self.inputs.push(inputObj);
 	
-				if (parseInt(inputNumber) % 2 === 0) {
+				if (parseInt(objKeys[i].toString()) % 2 === 0) {
 					//even number, so create the stereo channel with the previous channel
 					inputNumber = objKeys[i-1] + '_' + objKeys[i];
 					inputName = 'Analog ' + objKeys[i-1] + '+' + objKeys[i];


### PR DESCRIPTION
On Dante-enabled amplifiers, when trying to set an input from companion, it wasn't possible to use Analog inputs because the input IDs overlapped.  They were just 1, 2, 1_2, 3, 4, 3_4.  Now the Dante inputs have a "D" prefix.  So the input list IDs now look like D1, D2, D1_2, D3, D4, D3_4, 1, 2, 1_2, 3, 4, 3_4.
